### PR TITLE
[#CU-866b122c3] Tailwind 클래스 정렬을 위한 Prettier 플러그인 추가

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
   "singleQuote": true,
   "jsxSingleQuote": true,
   "endOfLine": "auto",
-  "printWidth": 120
+  "printWidth": 120,
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-react-refresh": "^0.4.3",
         "postcss": "^8.4.31",
         "prettier": "^3.0.3",
+        "prettier-plugin-tailwindcss": "^0.5.7",
         "tailwindcss": "^3.3.3",
         "typescript": "^5.0.2",
         "vite": "^4.4.5",
@@ -3305,6 +3306,78 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.7.tgz",
+      "integrity": "sha512-4v6uESAgwCni6YF6DwJlRaDjg9Z+al5zM4JfngcazMy4WEf/XkPS5TEQjbD+DZ5iNuG6RrKQLa/HuX2SYzC3kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@shufo/prettier-plugin-blade": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@shufo/prettier-plugin-blade": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "prettier-plugin-twig-melody": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6403,6 +6476,13 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.7.tgz",
+      "integrity": "sha512-4v6uESAgwCni6YF6DwJlRaDjg9Z+al5zM4JfngcazMy4WEf/XkPS5TEQjbD+DZ5iNuG6RrKQLa/HuX2SYzC3kQ==",
+      "dev": true,
+      "requires": {}
     },
     "punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-react-refresh": "^0.4.3",
     "postcss": "^8.4.31",
     "prettier": "^3.0.3",
+    "prettier-plugin-tailwindcss": "^0.5.7",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import WallpaperUrl from './assets/wallpaper.jpg';
 
 function App() {
   return (
-    <div className='w-full h-screen'>
-      <img src={WallpaperUrl} className='absolute w-full h-full object-cover' />
+    <div className='h-screen w-full'>
+      <img src={WallpaperUrl} className='absolute h-full w-full object-cover' />
       <MenuBar />
       {/* Desktop */}
       {/* Dock */}

--- a/src/components/MenuBar/MenuItem.tsx
+++ b/src/components/MenuBar/MenuItem.tsx
@@ -5,7 +5,7 @@ const MenuItem = ({ isAppName = false, children }: { isAppName?: boolean; childr
   return (
     <button
       type='button'
-      className={`text-[13px] leading-[16px] text rounded-[4px] px-[11px] py-[4px] active:bg-[#090909]/10 cursor-default ${fontWeightClass}`}
+      className={`text cursor-default rounded-[4px] px-[11px] py-[4px] text-[13px] leading-[16px] active:bg-[#090909]/10 ${fontWeightClass}`}
     >
       {children}
     </button>

--- a/src/components/MenuBar/index.tsx
+++ b/src/components/MenuBar/index.tsx
@@ -7,7 +7,7 @@ import Clock from './Clock';
 
 const MenuBar = () => {
   return (
-    <div className='w-full bg-white/50 backdrop-blur-[25px] flex justify-between pl-[4px] pr-[8px]'>
+    <div className='flex w-full justify-between bg-white/50 pl-[4px] pr-[8px] backdrop-blur-[25px]'>
       <div className='flex gap-[-4px]'>
         <MenuItem>
           <AppleIcon width={14} height={17} viewBox='0 0 14 17' />


### PR DESCRIPTION
# 구현 내용

* Tailwind 클래스 정렬을 위한 [Prettier 플러그인](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier)을 추가했어요.
