### PR TITLE
[#CU-86epa8zaz] 모바일 페이지 대응

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,18 +7,24 @@ import OverlayProvider from './store/Overlay/OverlayProvider';
 import SystemProvider from './store/System/SystemProvider';
 import { useContext } from 'react';
 import { SystemStateContext } from './store/System/SystemContext';
+import useWindowResize from './hooks/useWindowResize';
 
 function App() {
   return (
     <SystemProvider>
       <AppProvider>
         <OverlayProvider>
-          <Desktop />
+          <ResponsiveScreen />
         </OverlayProvider>
       </AppProvider>
     </SystemProvider>
   );
 }
+
+const ResponsiveScreen = () => {
+  const isAvailableWindowSize = useWindowResize();
+  return isAvailableWindowSize ? <Desktop /> : <Mobile />;
+};
 
 const Desktop = () => {
   const { brightness } = useContext(SystemStateContext);
@@ -33,6 +39,15 @@ const Desktop = () => {
       <MenuBar />
       <WindowWrapper />
       <Dock />
+    </div>
+  );
+};
+
+const Mobile = () => {
+  return (
+    <div>
+      <h1>앱이 지원하지 않는 스크린 사이즈입니다.</h1>
+      <p>최소 넓이: 1024px, 최소 높이: 768px</p>
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,9 +45,9 @@ const Desktop = () => {
 
 const Mobile = () => {
   return (
-    <div>
-      <h1>앱이 지원하지 않는 스크린 사이즈입니다.</h1>
-      <p>최소 넓이: 1024px, 최소 높이: 768px</p>
+    <div className='flex h-screen w-full flex-col items-center justify-center gap-2 break-keep bg-slate-700 px-2 text-center text-slate-100'>
+      <h1 className='text-[2rem] font-semibold'>앱이 지원하지 않는 스크린 사이즈입니다.</h1>
+      <p className='text-[1rem]'>최소 넓이: 1024px, 최소 높이: 768px</p>
     </div>
   );
 };

--- a/src/constants/resize.ts
+++ b/src/constants/resize.ts
@@ -1,2 +1,5 @@
+export const WINDOW_MIN_WIDTH = 1024;
+export const WINDOW_MIN_HEIGHT = 768;
+
 export const BOUNDARY_MIN = 0;
 export const BOUNDARY_MARGIN = 20;

--- a/src/hooks/useWindowResize.ts
+++ b/src/hooks/useWindowResize.ts
@@ -1,0 +1,29 @@
+import { WINDOW_MIN_HEIGHT, WINDOW_MIN_WIDTH } from '@/constants/resize';
+import { useEffect, useState } from 'react';
+
+const useWindowResize = () => {
+  const [isAvailableWindowSize, setIsAvailableWindowSize] = useState(false);
+
+  const resizeHandler = () => {
+    const { innerWidth: width, innerHeight: height } = window;
+
+    if (width <= WINDOW_MIN_WIDTH || height <= WINDOW_MIN_HEIGHT) {
+      setIsAvailableWindowSize(false);
+      return;
+    }
+
+    setIsAvailableWindowSize(true);
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', resizeHandler);
+
+    return () => {
+      window.removeEventListener('resize', resizeHandler);
+    };
+  }, []);
+
+  return isAvailableWindowSize;
+};
+
+export default useWindowResize;

--- a/src/hooks/useWindowResize.ts
+++ b/src/hooks/useWindowResize.ts
@@ -16,6 +16,7 @@ const useWindowResize = () => {
   };
 
   useEffect(() => {
+    resizeHandler();
     window.addEventListener('resize', resizeHandler);
 
     return () => {


### PR DESCRIPTION
# 구현 내용

* 지원하고 있지 않은 모바일에서 접근했을 때를 위한 모바일용 안내 페이지를 추가했어요.

# 스크린샷

![image](https://github.com/shaw-kee/shawkee-os/assets/48359052/6c028709-6499-4cf7-bcd2-b8608123a7fe)

# 기타 공유사항

* 테스트를 하다가, 밝기 조절 기능이 Overlay 컴포넌트에는 적용되지 않는 문제를 확인했어요. 나중에 수정되어야 할 것 같습니다 😅 
<!-- - ex) XX를 해결하려는데 잘 안되네요. 좋은 방법이 있을까요? -->
